### PR TITLE
Fix the argument count of the failed notification window call

### DIFF
--- a/github_notif
+++ b/github_notif
@@ -114,7 +114,7 @@ function show_all_notifications () {
 function show_notification_about_failure () {
   config_url=$1
   error_message=$2
-  show_notification_window "Failed to fetch a notification" "$error_message" "$config_url/notifications"
+  show_notification_window "Failed to fetch a notification" "$error_message" "" "$config_url/notifications"
 }
 
 function show_missed_notifications() {
@@ -135,7 +135,6 @@ function show_missed_notifications() {
       error_message=$(show_notification "$access_token" "$notifications_json" $i)
       local call_result=$?
       if [[ $call_result -ne 0 ]]; then
-        log_error "An error occured while showing notification. $error_message"
         if (( $NOTIFY_ABOUT_FAILED_NOTIFICATIONS == 1 )); then
           show_notification_about_failure "$config_url" "$error_message"
         fi;

--- a/test/github_notif_test.sh
+++ b/test/github_notif_test.sh
@@ -154,7 +154,7 @@ test_show_missed_notifications_on_failing_notification_details_call() {
   local shown_date=0
   show_missed_notifications https://github.com token "$NOTIFICATIONS_JSON" $shown_date > $SHUNIT_TMPDIR/last_shown_date
   assertEquals 0 $?
-  verify_with_all_args terminal_notifier "Failed to fetch a notification Failed to connect to https://api.github.com/repos/octokit/octokit.rb/issues/comments/123 https://github.com/notifications"
+  verify_with_all_args terminal_notifier "Failed to fetch a notification Failed to connect to https://api.github.com/repos/octokit/octokit.rb/issues/comments/123  https://github.com/notifications"
   verify_with_all_args terminal_notifier "More missed notifications on github.com" "See all" "" https://github.com/notifications
 }
 


### PR DESCRIPTION
Addresses an issue introduced while fixing #19 